### PR TITLE
Add downloaded indicator to EpisodeCell

### DIFF
--- a/Sora/Views/MediaInfoView/EpisodeCell/EpisodeCell.swift
+++ b/Sora/Views/MediaInfoView/EpisodeCell/EpisodeCell.swift
@@ -149,6 +149,10 @@ private extension EpisodeCell {
             episodeThumbnail
             episodeInfo
             Spacer()
+            if case .downloaded = downloadStatus {
+                downloadedIndicator
+                    .padding(.trailing, 8)
+            }
             CircularProgressBar(progress: currentProgress)
                 .frame(width: 40, height: 40)
                 .padding(.trailing, 4)
@@ -226,6 +230,12 @@ private extension EpisodeCell {
                     .foregroundColor(.secondary)
             }
         }
+    }
+    
+    var downloadedIndicator: some View {
+        Image(systemName: "folder.fill")
+            .foregroundColor(.green)
+            .font(.system(size: 18))
     }
     
     var contextMenuContent: some View {

--- a/Sora/Views/MediaInfoView/EpisodeCell/EpisodeCell.swift
+++ b/Sora/Views/MediaInfoView/EpisodeCell/EpisodeCell.swift
@@ -234,7 +234,7 @@ private extension EpisodeCell {
     
     var downloadedIndicator: some View {
         Image(systemName: "folder.fill")
-            .foregroundColor(.green)
+            .foregroundColor(.accentColor)
             .font(.system(size: 18))
     }
     


### PR DESCRIPTION
- Introduced a visual indicator for downloaded episodes, displayed when the download status is 'downloaded'.
- Added a green folder icon to signify downloaded content