### PR TITLE
Download persistence system revamp 

### DIFF
--- a/Sora/Utlis & Misc/DownloadUtils/DownloadPersistence.swift
+++ b/Sora/Utlis & Misc/DownloadUtils/DownloadPersistence.swift
@@ -1,0 +1,107 @@
+//
+//  DownloadPersistence.swift
+//  Sora
+//
+//  iOS 15 JSON + UserDefaults persistence layer.
+//
+
+import Foundation
+
+/// Where the master JSON lives
+private var documentsDirectory: URL {
+    FileManager.default.urls(for: .applicationSupportDirectory,
+                             in: .userDomainMask).first!
+        .appendingPathComponent("SoraDownloads")
+}
+
+/// Master JSON file name
+private let jsonFileName = "downloads.json"
+
+/// Light index in UserDefaults (UUID → file name, for instant look-ups)
+private let defaultsKey = "downloadIndex"
+
+/// Root object that is written to JSON
+private struct DiskStore: Codable {
+    var assets: [DownloadedAsset] = []
+}
+
+/// Singleton façade
+enum DownloadPersistence {
+
+    // MARK: - Public API
+
+    /// Loads the entire catalogue
+    static func load() -> [DownloadedAsset] {
+        migrateIfNeeded()
+        return readStore().assets
+    }
+
+    /// Saves the entire catalogue
+    static func save(_ assets: [DownloadedAsset]) {
+        writeStore(DiskStore(assets: assets))
+        updateDefaultsIndex(from: assets)
+    }
+
+    /// Adds or replaces one asset
+    static func upsert(_ asset: DownloadedAsset) {
+        var assets = load()
+        assets.removeAll { $0.id == asset.id }
+        assets.append(asset)
+        save(assets)
+    }
+
+    /// Deletes one asset
+    static func delete(id: UUID) {
+        var assets = load()
+        assets.removeAll { $0.id == id }
+        save(assets)
+    }
+
+    // MARK: - Internal helpers
+
+    private static func readStore() -> DiskStore {
+        let url = documentsDirectory.appendingPathComponent(jsonFileName)
+        guard FileManager.default.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode(DiskStore.self, from: data)
+        else { return DiskStore() }
+        return decoded
+    }
+
+    private static func writeStore(_ store: DiskStore) {
+        try? FileManager.default.createDirectory(at: documentsDirectory,
+                                                 withIntermediateDirectories: true)
+        let url = documentsDirectory.appendingPathComponent(jsonFileName)
+        guard let data = try? JSONEncoder().encode(store) else { return }
+        try? data.write(to: url)
+    }
+
+    /// Keeps UserDefaults in sync: [UUID → file name]
+    private static func updateDefaultsIndex(from assets: [DownloadedAsset]) {
+        let dict = Dictionary(uniqueKeysWithValues:
+            assets.map { ($0.id.uuidString, $0.localURL.lastPathComponent) })
+        UserDefaults.standard.set(dict, forKey: defaultsKey)
+    }
+
+    // MARK: - One-time migration from old UserDefaults store
+
+    private static var migrationDoneKey = "migrationToJSONDone"
+
+    private static func migrateIfNeeded() {
+        guard !UserDefaults.standard.bool(forKey: migrationDoneKey),
+              let oldData = UserDefaults.standard.data(forKey: "downloadedAssets") else {
+            return
+        }
+
+        do {
+            let oldAssets = try JSONDecoder().decode([DownloadedAsset].self, from: oldData)
+            save(oldAssets)
+            UserDefaults.standard.set(true, forKey: migrationDoneKey)
+            // Remove old key to avoid bloat
+            UserDefaults.standard.removeObject(forKey: "downloadedAssets")
+        } catch {
+            // Couldn’t decode – ignore and start fresh
+            UserDefaults.standard.set(true, forKey: migrationDoneKey)
+        }
+    }
+}

--- a/Sora/Utlis & Misc/DownloadUtils/DownloadPersistence.swift
+++ b/Sora/Utlis & Misc/DownloadUtils/DownloadPersistence.swift
@@ -7,58 +7,42 @@
 
 import Foundation
 
-/// Where the master JSON lives
 private var documentsDirectory: URL {
-    FileManager.default.urls(for: .applicationSupportDirectory,
-                             in: .userDomainMask).first!
+    FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         .appendingPathComponent("SoraDownloads")
 }
 
-/// Master JSON file name
 private let jsonFileName = "downloads.json"
-
-/// Light index in UserDefaults (UUID → file name, for instant look-ups)
 private let defaultsKey = "downloadIndex"
 
-/// Root object that is written to JSON
 private struct DiskStore: Codable {
     var assets: [DownloadedAsset] = []
 }
 
-/// Singleton façade
 enum DownloadPersistence {
-
-    // MARK: - Public API
-
-    /// Loads the entire catalogue
     static func load() -> [DownloadedAsset] {
         migrateIfNeeded()
         return readStore().assets
     }
-
-    /// Saves the entire catalogue
+    
     static func save(_ assets: [DownloadedAsset]) {
         writeStore(DiskStore(assets: assets))
         updateDefaultsIndex(from: assets)
     }
-
-    /// Adds or replaces one asset
+    
     static func upsert(_ asset: DownloadedAsset) {
         var assets = load()
         assets.removeAll { $0.id == asset.id }
         assets.append(asset)
         save(assets)
     }
-
-    /// Deletes one asset
+    
     static func delete(id: UUID) {
         var assets = load()
         assets.removeAll { $0.id == id }
         save(assets)
     }
-
-    // MARK: - Internal helpers
-
+    
     private static func readStore() -> DiskStore {
         let url = documentsDirectory.appendingPathComponent(jsonFileName)
         guard FileManager.default.fileExists(atPath: url.path),
@@ -67,7 +51,7 @@ enum DownloadPersistence {
         else { return DiskStore() }
         return decoded
     }
-
+    
     private static func writeStore(_ store: DiskStore) {
         try? FileManager.default.createDirectory(at: documentsDirectory,
                                                  withIntermediateDirectories: true)
@@ -75,32 +59,27 @@ enum DownloadPersistence {
         guard let data = try? JSONEncoder().encode(store) else { return }
         try? data.write(to: url)
     }
-
-    /// Keeps UserDefaults in sync: [UUID → file name]
+    
     private static func updateDefaultsIndex(from assets: [DownloadedAsset]) {
         let dict = Dictionary(uniqueKeysWithValues:
-            assets.map { ($0.id.uuidString, $0.localURL.lastPathComponent) })
+                                assets.map { ($0.id.uuidString, $0.localURL.lastPathComponent) })
         UserDefaults.standard.set(dict, forKey: defaultsKey)
     }
-
-    // MARK: - One-time migration from old UserDefaults store
-
+    
     private static var migrationDoneKey = "migrationToJSONDone"
-
+    
     private static func migrateIfNeeded() {
         guard !UserDefaults.standard.bool(forKey: migrationDoneKey),
               let oldData = UserDefaults.standard.data(forKey: "downloadedAssets") else {
             return
         }
-
+        
         do {
             let oldAssets = try JSONDecoder().decode([DownloadedAsset].self, from: oldData)
             save(oldAssets)
             UserDefaults.standard.set(true, forKey: migrationDoneKey)
-            // Remove old key to avoid bloat
             UserDefaults.standard.removeObject(forKey: "downloadedAssets")
         } catch {
-            // Couldn’t decode – ignore and start fresh
             UserDefaults.standard.set(true, forKey: migrationDoneKey)
         }
     }

--- a/Sora/Utlis & Misc/DownloadUtils/DownloadPersistence.swift
+++ b/Sora/Utlis & Misc/DownloadUtils/DownloadPersistence.swift
@@ -1,8 +1,8 @@
 //
 //  DownloadPersistence.swift
-//  Sora
+//  Sulfur
 //
-//  iOS 15 JSON + UserDefaults persistence layer.
+//  Created by doomsboygaming on 15/07/25.
 //
 
 import Foundation

--- a/Sulfur.xcodeproj/project.pbxproj
+++ b/Sulfur.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		72443C7D2DC8036500A61321 /* DownloadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72443C7C2DC8036500A61321 /* DownloadView.swift */; };
 		72443C7F2DC8038300A61321 /* SettingsViewDownloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72443C7E2DC8038300A61321 /* SettingsViewDownloads.swift */; };
 		727220712DD642B100C2A4A2 /* JSController-StreamTypeDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7272206F2DD642B100C2A4A2 /* JSController-StreamTypeDownload.swift */; };
+		7273F0402E26B19700DF083D /* DownloadPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7273F03F2E26B19700DF083D /* DownloadPersistence.swift */; };
 		72D546DB2DFC5E950044C567 /* JSController+Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D546DA2DFC5E950044C567 /* JSController+Downloader.swift */; };
 		73D164D52D8B5B470011A360 /* JavaScriptCore+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D164D42D8B5B340011A360 /* JavaScriptCore+Extensions.swift */; };
 /* End PBXBuildFile section */
@@ -238,6 +239,7 @@
 		72443C7C2DC8036500A61321 /* DownloadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadView.swift; sourceTree = "<group>"; };
 		72443C7E2DC8038300A61321 /* SettingsViewDownloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewDownloads.swift; sourceTree = "<group>"; };
 		7272206F2DD642B100C2A4A2 /* JSController-StreamTypeDownload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSController-StreamTypeDownload.swift"; sourceTree = "<group>"; };
+		7273F03F2E26B19700DF083D /* DownloadPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadPersistence.swift; sourceTree = "<group>"; };
 		72D546DA2DFC5E950044C567 /* JSController+Downloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSController+Downloader.swift"; sourceTree = "<group>"; };
 		73D164D42D8B5B340011A360 /* JavaScriptCore+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JavaScriptCore+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -852,6 +854,7 @@
 		72443C832DC8046500A61321 /* DownloadUtils */ = {
 			isa = PBXGroup;
 			children = (
+				7273F03F2E26B19700DF083D /* DownloadPersistence.swift */,
 				7222485D2DCBAA2C00CABE2D /* DownloadModels.swift */,
 				131270162DC13A010093AA9C /* DownloadManager.swift */,
 				7222485E2DCBAA2C00CABE2D /* M3U8StreamExtractor.swift */,
@@ -1051,6 +1054,7 @@
 				13EA2BD52D32D97400C1EBD7 /* CustomPlayer.swift in Sources */,
 				727220712DD642B100C2A4A2 /* JSController-StreamTypeDownload.swift in Sources */,
 				0402DA132DE7B5EC003BB42C /* SearchStateView.swift in Sources */,
+				7273F0402E26B19700DF083D /* DownloadPersistence.swift in Sources */,
 				0402DA142DE7B5EC003BB42C /* SearchResultsGrid.swift in Sources */,
 				72D546DB2DFC5E950044C567 /* JSController+Downloader.swift in Sources */,
 				0402DA152DE7B5EC003BB42C /* SearchComponents.swift in Sources */,


### PR DESCRIPTION
# Key Changes

## 1. Persistence Layer Migration

**Replaced all usages of:**
- `UserDefaults.standard.data(forKey: "downloadedAssets")`
- `UserDefaults.standard.set(data, forKey: "downloadedAssets")`
- Manual array mutation:
  - `savedAssets.append(...)`
  - `savedAssets.removeAll { $0.id == id }`

**Now uses:**
- `DownloadPersistence.load()`
- `DownloadPersistence.save(assets)`
- `DownloadPersistence.upsert(newAsset)`
- `DownloadPersistence.delete(id: id)`

## 2. Reactive Downloaded View

- After any download change (add, delete, or update), `savedAssets` is reloaded from disk.
- `objectWillChange.send()` is called on the **main thread**.
- Ensures the **Downloaded view** and all SwiftUI consumers update immediately.

## 3. Download Completion Handling

- When a file finishes downloading:
  - The asset is persisted.
  - The UI reflects the new download **immediately**.

## 4. Subtitle File Deletion

- Subtitle deletion is now **robust**:
  - If `localSubtitleURL` is `nil` or missing:
    - Searches for files matching the asset’s ID and common subtitle extensions (`.vtt`, `.srt`, `.webvtt`) in the persistent directory.
- Prevents orphaned files and keeps storage clean.

## 5. General Cleanup

- All legacy persistence logic removed.
- No direct `UserDefaults` usage remains for downloads.
